### PR TITLE
Adding the word 'optional' to query docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A string containing the SQL query.
 
 #### `values`
 
-An array of values matching the `?` placeholders in the SQL query.
+An optional array of values matching the `?` placeholders in the SQL query.
 
 #### `callback`
 


### PR DESCRIPTION
Makes it more obvious that the array can be omitted if not needed for the query.
