### PR TITLE
Fix for turkish locale bug

### DIFF
--- a/src/android/io/sqlc/SQLiteAndroidDatabase.java
+++ b/src/android/io/sqlc/SQLiteAndroidDatabase.java
@@ -23,6 +23,7 @@ import java.lang.IllegalArgumentException;
 import java.lang.Number;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 import org.apache.cordova.CallbackContext;
 
@@ -494,7 +495,7 @@ class SQLiteAndroidDatabase
         Matcher matcher = FIRST_WORD.matcher(query);
         if (matcher.find()) {
             try {
-                return QueryType.valueOf(matcher.group(1).toLowerCase());
+                return QueryType.valueOf(matcher.group(1).toLowerCase(Locale.ENGLISH));
             } catch (IllegalArgumentException ignore) {
                 // unknown verb
             }


### PR DESCRIPTION
While in turkish locale, transforming string with letters 'I' and 'i' to lowercase/uppercase cause these letters to be transofrmed into İ and ı respectively, which are not I nor i, notice the difference. This causes an exception in obtaining query type, as ınsert != insert.